### PR TITLE
Add gaming PC Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@
 AlexBrodskii/AlexBrodskii is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## Projects
+- [Gaming PC Selector Bot](telegram_bot/README.md)

--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -1,0 +1,15 @@
+# Gaming PC Selector Bot
+
+A simple Telegram bot that helps users choose a gaming PC configuration.
+
+## Setup
+1. Install dependencies:
+```bash
+pip install pytelegrambotapi
+```
+2. Create a bot in Telegram and obtain its token.
+3. Set an environment variable `TELEGRAM_TOKEN` with your bot token or replace the placeholder in `pc_selector_bot.py`.
+4. Run the bot:
+```bash
+python pc_selector_bot.py
+```

--- a/telegram_bot/pc_selector_bot.py
+++ b/telegram_bot/pc_selector_bot.py
@@ -1,0 +1,50 @@
+import os
+import telebot
+from telebot import types
+
+TOKEN = os.getenv("TELEGRAM_TOKEN", "YOUR_API_TOKEN_HERE")
+
+bot = telebot.TeleBot(TOKEN)
+
+CATEGORY_KEYBOARD = ['Бюджетный', 'Средний', 'Топовый']
+
+CONFIGS = {
+    'Бюджетный': (
+        "Бюджетная сборка:\n"
+        "- CPU: AMD Ryzen 5\n"
+        "- GPU: NVIDIA GTX 1660\n"
+        "- RAM: 16GB"
+    ),
+    'Средний': (
+        "Средняя сборка:\n"
+        "- CPU: AMD Ryzen 7\n"
+        "- GPU: NVIDIA RTX 3060\n"
+        "- RAM: 32GB"
+    ),
+    'Топовый': (
+        "Топовая сборка:\n"
+        "- CPU: Intel Core i9\n"
+        "- GPU: NVIDIA RTX 4090\n"
+        "- RAM: 64GB"
+    ),
+}
+
+@bot.message_handler(commands=['start'])
+def handle_start(message: types.Message):
+    markup = types.ReplyKeyboardMarkup(one_time_keyboard=True, resize_keyboard=True)
+    for cat in CATEGORY_KEYBOARD:
+        markup.add(cat)
+    bot.send_message(
+        message.chat.id,
+        "Привет! Выберите категорию игрового ПК:",
+        reply_markup=markup
+    )
+
+@bot.message_handler(func=lambda m: m.text in CATEGORY_KEYBOARD)
+def handle_selection(message: types.Message):
+    config = CONFIGS.get(message.text, "Конфигурация не найдена")
+    bot.send_message(message.chat.id, config)
+
+if __name__ == '__main__':
+    print("Bot is running...")
+    bot.infinity_polling()


### PR DESCRIPTION
## Summary
- add simple Telegram bot for selecting gaming PC
- document bot usage
- link to bot from main README

## Testing
- `python3 -m py_compile telegram_bot/pc_selector_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685b04df77708320ae5c7ad71c92bde9